### PR TITLE
Revert "Do not use `aiohttp=3.11.0` in tests"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-aiohttp!=3.11.0 # https://github.com/pnuckowski/aioresponses/issues/263
 aioresponses
 covdefaults>=2.1.0
 coverage


### PR DESCRIPTION
Reverts mxr/sqlite-export-for-ynab#44 as the upstream issue was fixed