### PR TITLE
Make file IO async

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,4 +46,5 @@ repos:
   rev: v1.20.1
   hooks:
   - id: mypy
+    additional_dependencies: [aiopathlib]
     language_version: python3.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ keywords = ynab, sqlite, sql, budget, plan, cli
 packages = find:
 install_requires =
     aiohttp>=3
+    aiopathlib
     aiosqlite
     tldm
 python_requires = >=3.12

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -21,6 +21,7 @@ from urllib.parse import urlunparse
 
 import aiohttp
 import aiosqlite
+from aiopathlib import AsyncPath
 from tldm import tldm
 
 from sqlite_export_for_ynab import ddl
@@ -132,8 +133,7 @@ async def sync(
 
     plan_ids = [plan["id"] for plan in plans]
 
-    if not db.exists():
-        db.parent.mkdir(parents=True, exist_ok=True)
+    await AsyncPath(db).parent.mkdir(parents=True, exist_ok=True)
 
     async with aiosqlite.connect(db) as con:
         con.row_factory = aiosqlite.Row
@@ -141,7 +141,7 @@ async def sync(
         if full_refresh:
             _print("Dropping relations...", quiet=quiet)
             async with con.cursor() as cur:
-                await cur.executescript(contents("drop-relations.sql"))
+                await cur.executescript(await contents("drop-relations.sql"))
             await con.commit()
             _print("Done", quiet=quiet)
 
@@ -149,7 +149,7 @@ async def sync(
             relations = await get_relations(cur)
             if relations != _ALL_RELATIONS:
                 _print("Recreating relations...", quiet=quiet)
-                await cur.executescript(contents("create-relations.sql"))
+                await cur.executescript(await contents("create-relations.sql"))
                 await con.commit()
                 _print("Done", quiet=quiet)
 
@@ -254,8 +254,8 @@ async def sync(
             _print("Done", quiet=quiet)
 
 
-def contents(filename: str) -> str:
-    return (resources.files(ddl) / filename).read_text()
+async def contents(filename: str) -> str:
+    return await AsyncPath(resources.files(ddl) / filename).read_text()
 
 
 async def get_relations(cur: aiosqlite.Cursor) -> set[str]:

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -357,7 +357,7 @@ SCHEDULED_TRANSACTIONS: list[dict[str, Any]] = [
 async def con():
     async with aiosqlite.connect(":memory:") as con:
         con.row_factory = aiosqlite.Row
-        await con.executescript(contents("create-relations.sql"))
+        await con.executescript(await contents("create-relations.sql"))
         yield con
 
 

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -722,7 +722,7 @@ async def test_sync_no_data(tmp_path, mock_aioresponses):
     # create the db and tables to exercise all code branches
     db = tmp_path / "db.sqlite"
     async with aiosqlite.connect(db) as con:
-        await con.executescript(contents("create-relations.sql"))
+        await con.executescript(await contents("create-relations.sql"))
 
     await sync(TOKEN, db, False)
 
@@ -766,7 +766,7 @@ async def test_sync_no_data_quiet(tmp_path, mock_aioresponses, capsys):
 
     db = tmp_path / "db.sqlite"
     async with aiosqlite.connect(db) as con:
-        await con.executescript(contents("create-relations.sql"))
+        await con.executescript(await contents("create-relations.sql"))
 
     await sync(TOKEN, db, False, quiet=True)
 


### PR DESCRIPTION
#### Problem
Home Assistant detects the packaged DDL reads and related path operations as blocking calls when sync runs inside an event loop.

#### Solution
Use aiopathlib for async DDL reads and parent directory creation. Add aiopathlib to runtime dependencies and the mypy hook environment.