### PR TITLE
Reference latest Actions patch versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       project_files: ${{ steps.filter.outputs.project_files }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:


### PR DESCRIPTION
#### Problem
Pinned GitHub Actions refs should identify the exact upstream patch version they came from.

#### Solution
Update workflow action comments to the latest stable patch tag for each pinned action major version while keeping full commit SHA pins.
