### PR TITLE
Migrate zizmor to pre-commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,15 +28,6 @@ jobs:
             - '**/*requirements*.txt'
             - '**/setup.cfg'
             - setup.py
-  zizmor:
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
-      with:
-        persist-credentials: false
-    - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e   # v0.5.3
   main-real:
     needs: [changes]
     if: needs.changes.outputs.project_files == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,8 @@ repos:
     - asyncio-for-ynab
     - rich>=10
     language_version: python3.12
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: v1.24.1
+  hooks:
+  - id: zizmor
+    args: [--no-progress, --fix]


### PR DESCRIPTION
#### Problem
Zizmor was enforced through a dedicated workflow and repository ruleset in this repo.

#### Solution
Move Zizmor to pre-commit, remove the workflow-based check, and drop the Zizmor ruleset requirement.