### PR TITLE
Inline PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,32 @@ concurrency:
 
 jobs:
   release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
     permissions:
       contents: write
       id-token: write
-    uses: mxr/workflows/.github/workflows/pypi-release.yml@f0281d9a23f65774fe530a52f03d5419ed871519 # v0.1.0
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.12'
+    - name: Install build tooling
+      shell: bash
+      run: python -m pip install build
+    - name: Build distributions
+      shell: bash
+      run: python -m build
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      with:
+        packages-dir: dist/
+    - name: Create GitHub release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release create "$GITHUB_REF_NAME" dist/* --verify-tag --generate-notes


### PR DESCRIPTION
#### Problem
The release workflow depended on the shared PyPI release workflow. The repo should own the release steps directly.

#### Solution
Inline the build, publish, and GitHub release steps in `release.yml`. Keep pinned action versions and trusted publishing permissions.