### PR TITLE
Fix interest query sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ WITH interest_by_account AS (
     SELECT
         plan_id
         , account_name
-        , SUM(-amount_currency) AS total
+        , SUM(amount_currency) AS total
     FROM flat_transactions
     WHERE
         TRUE


### PR DESCRIPTION
#### Problem
Interest is recorded as inflows (positive `amount_currency`). The query negated the amount, so per-account totals were negative. They failed the `HAVING total >= threshold` filter, so reported interest fell back to $0.

#### Solution
Sum `amount_currency` directly instead of negating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)