### PR TITLE
Ignore unknown YNAB API fields on insert

### DIFF
--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -603,7 +603,13 @@ async def insert_entries(
     if not entries:
         return
 
-    entry_keys = tuple(entries[0])
+    async with context.con.cursor() as cur:
+        await cur.execute(f"PRAGMA table_info({table})")
+        table_columns = {row["name"] async for row in cur}
+
+    # Ignore any keys the YNAB API returns that aren't columns in the DDL so
+    # newly-added API fields don't break the insert.
+    entry_keys = tuple(k for k in entries[0] if k in table_columns)
     sql = f"INSERT OR REPLACE INTO {table} ({', '.join(entry_keys + ('plan_id',))}) VALUES ({', '.join('?' * (len(entry_keys) + 1))})"
 
     async with context.con.cursor() as cur:

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -29,6 +29,7 @@ from sqlite_export_for_ynab._main import get_last_knowledge_of_server
 from sqlite_export_for_ynab._main import get_relations
 from sqlite_export_for_ynab._main import insert_accounts
 from sqlite_export_for_ynab._main import insert_category_groups
+from sqlite_export_for_ynab._main import insert_entries
 from sqlite_export_for_ynab._main import insert_payees
 from sqlite_export_for_ynab._main import insert_plans
 from sqlite_export_for_ynab._main import insert_scheduled_transactions
@@ -495,6 +496,31 @@ async def test_insert_payees(context):
                 "transfer_account_id": None,
                 "deleted": False,
             },
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_insert_entries_ignores_unknown_keys(context):
+    task_id = context.progress.add_task("Payees", total=1)
+    entry = {
+        "id": PAYEE_ID_1,
+        "name": "Payee",
+        "transfer_account_id": None,
+        "deleted": False,
+        "brand_new_api_field": "surprise",
+    }
+    await insert_entries(context, "payees", PLAN_ID_1, [entry], task_id)
+    assert_rows(
+        await fetchall(context.con, "SELECT * FROM payees"),
+        [
+            {
+                "id": PAYEE_ID_1,
+                "plan_id": PLAN_ID_1,
+                "name": "Payee",
+                "transfer_account_id": None,
+                "deleted": False,
+            }
         ],
     )
 


### PR DESCRIPTION
#### Problem

When the YNAB API returns a new field not in the DDL, `insert_entries` builds an INSERT with that column and SQLite raises `table X has no column named Y`. The whole export fails.

#### Solution

Query the table columns via `PRAGMA table_info` and keep only entry keys that exist. New API fields are silently ignored.