### PR TITLE
Scope package-data: py.typed to root, SQL to ddl subpackage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,8 @@ extend-select = [
 ]
 
 [tool.setuptools.package-data]
-"*" = ["*.sql"]
 sqlite_export_for_ynab = ["py.typed"]
+"sqlite_export_for_ynab.ddl" = ["*.sql"]
 
 [tool.setuptools.packages]
 find = {}


### PR DESCRIPTION
#### Problem
`"*" = ["*.sql"]` includes SQL in all packages broadly; SQL files only live in `sqlite_export_for_ynab.ddl`.

#### Solution
Scope `py.typed` to root package and `*.sql` to `sqlite_export_for_ynab.ddl` explicitly.