### PR TITLE
Add ty type checker with all rules as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,6 @@ commands = [
   ["coverage", "report"],
 ]
 dependency_groups = ["dev"]
+
+[tool.ty.rules]
+all = "error"

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 from typing import Literal
 from typing import overload
+from typing import override
 from typing import TYPE_CHECKING
 
 import aiosqlite
@@ -67,6 +68,7 @@ except ImportError:  # pragma: no cover
             self.separator = separator
             super().__init__(table_column=table_column)
 
+        @override
         def render(self, task: Task) -> Text:
             """Show completed/total."""
             completed = int(task.completed)


### PR DESCRIPTION
#### Problem
The project lacked ty type checker configuration, leaving potential type issues undetected.

#### Solution
Add `[tool.ty.rules] all = "error"` to pyproject.toml and add a missing `@override` decorator in `_main.py` to satisfy ty's checks.