### PR TITLE
Build ApiClient off the event loop thread

### DIFF
--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -219,8 +219,11 @@ async def _context(
     progress = Progress(*_PROGRESS_COLUMNS, disable=quiet)
     lock_path = db.parent / f"{db.name}.lock"
     lock = fasteners.InterProcessLock(lock_path)
+    # ApiClient's constructor builds an SSL context (loads certs from disk),
+    # so build it off the event loop thread.
+    api_client = await asyncio.to_thread(ApiClient, configuration)
     async with (
-        ApiClient(configuration) as api_client,
+        api_client,
         aiosqlite.connect(db) as con,
     ):
         con.row_factory = aiosqlite.Row


### PR DESCRIPTION
#### Problem
`ApiClient`'s constructor builds an SSL context synchronously (loads certs from disk), so `sync()` blocks the caller's event loop when run inside an async framework like Home Assistant.

#### Solution
Construct `ApiClient` via `asyncio.to_thread` so the blocking SSL context creation happens off the event loop.