### PR TITLE
Fix dependabot schedule cron syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ version: 2
 multi-ecosystem-groups:
   default:
     schedule:
-      interval: every day at 7am
+      interval: cron
+      cronjob: every day at 7am
 
 updates:
 - package-ecosystem: github-actions


### PR DESCRIPTION
#### Problem
Dependabot schedule used `interval: every day at 7am` instead of the correct `interval: cron` / `cronjob: every day at 7am` keys.

#### Solution
Set `interval: cron` and `cronjob: every day at 7am` under the schedule.