### PR TITLE
Chunk full-refresh transaction fetches by quarter

### DIFF
--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -716,23 +716,17 @@ class ChunkedTransactionsApi:
         today = date.today()
         responses = await asyncio.gather(
             *(
-                self._chunk(transactions_api, plan_id, since_date, until_date)
-                for since_date, until_date in _quarterly(self.first_month, today)
+                self._chunk(transactions_api, plan_id, sd, ud)
+                for sd, ud in _quarterly(self.first_month, today)
             )
         )
-        transactions = [
-            transaction
-            for response in responses
-            for transaction in response.data.transactions
-        ]
-        ids = [transaction.id for transaction in transactions]
+        transactions = [t for r in responses for t in r.data.transactions]
+        ids = [t.id for t in transactions]
         assert len(set(ids)) == len(ids)  # paranoid check for no overlap across chunks
         return TransactionsResponse(
             data=TransactionsResponseData(
                 transactions=transactions,
-                server_knowledge=max(
-                    response.data.server_knowledge for response in responses
-                ),
+                server_knowledge=max(r.data.server_knowledge for r in responses),
             )
         )
 
@@ -741,13 +735,13 @@ class ChunkedTransactionsApi:
         self,
         transactions_api: TransactionsApi,
         plan_id: str,
-        since_date: date,
-        until_date: date,
+        sd: date,
+        ud: date,
     ) -> TransactionsResponse:
         return await transactions_api.get_transactions(
             plan_id=plan_id,
-            since_date=since_date,
-            until_date=until_date,
+            since_date=sd,
+            until_date=ud,
         )
 
 

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -6,7 +6,6 @@ import os
 from contextlib import asynccontextmanager
 from contextlib import contextmanager
 from dataclasses import dataclass
-from dataclasses import field
 from dataclasses import fields
 from datetime import date
 from datetime import timedelta
@@ -657,7 +656,7 @@ async def _get_plan_data(
         py.get(AccountsApi(context.api_client).get_accounts),
         py.get(CategoriesApi(context.api_client).get_categories),
         py.get(PayeesApi(context.api_client).get_payees),
-        py.get_transactions(plan.first_month),
+        py.get_transactions(TransactionsApi(context.api_client), plan.first_month),
         py.get(ScheduledTransactionsApi(context.api_client).get_scheduled_transactions),
     )
     return (
@@ -679,10 +678,6 @@ class _ProgressYnab:
     plan_id: str
     lkos: dict[str, int]
     task_id: TaskID
-    _transactions_api: TransactionsApi = field(init=False)
-
-    def __post_init__(self) -> None:
-        self._transactions_api = TransactionsApi(self.context.api_client)
 
     @retry(stop=stop_after_attempt(3))
     async def get[T](self, endpoint: Callable[..., Awaitable[T]]) -> T:
@@ -694,36 +689,42 @@ class _ProgressYnab:
         finally:
             self.context.progress.update(self.task_id, advance=1)
 
-    async def get_transactions(self, first_month: date) -> TransactionsResponse:
+    async def get_transactions(
+        self, transactions_api: TransactionsApi, first_month: date
+    ) -> TransactionsResponse:
         last_knowledge_of_server = self.lkos.get(self.plan_id)
         try:
             if last_knowledge_of_server is not None:
-                return await self._transactions_api.get_transactions(
+                return await transactions_api.get_transactions(
                     plan_id=self.plan_id,
                     last_knowledge_of_server=last_knowledge_of_server,
                 )
-            return await self._get_transactions_in_chunks(first_month)
+            return await self._get_transactions_in_chunks(transactions_api, first_month)
         finally:
             self.context.progress.update(self.task_id, advance=1)
 
     async def _get_transactions_in_chunks(
-        self, first_month: date
+        self, transactions_api: TransactionsApi, first_month: date
     ) -> TransactionsResponse:
         today = date.today()
         responses = await asyncio.gather(
             *(
-                self._get_transactions_for_chunk(since_date, until_date)
+                self._get_transactions_for_chunk(
+                    transactions_api, since_date, until_date
+                )
                 for since_date, until_date in _quarterly_chunks(first_month, today)
             )
         )
-        transactions_by_id = {
-            transaction.id: transaction
+        transactions = [
+            transaction
             for response in responses
             for transaction in response.data.transactions
-        }
+        ]
+        ids = [transaction.id for transaction in transactions]
+        assert len(set(ids)) == len(ids)
         return TransactionsResponse(
             data=TransactionsResponseData(
-                transactions=list(transactions_by_id.values()),
+                transactions=transactions,
                 server_knowledge=max(
                     response.data.server_knowledge for response in responses
                 ),
@@ -732,9 +733,9 @@ class _ProgressYnab:
 
     @retry(stop=stop_after_attempt(3))
     async def _get_transactions_for_chunk(
-        self, since_date: date, until_date: date
+        self, transactions_api: TransactionsApi, since_date: date, until_date: date
     ) -> TransactionsResponse:
-        return await self._transactions_api.get_transactions(
+        return await transactions_api.get_transactions(
             plan_id=self.plan_id,
             since_date=since_date,
             until_date=until_date,

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -708,18 +708,16 @@ class ChunkedTransactionsApi:
                 plan_id=plan_id,
                 last_knowledge_of_server=last_knowledge_of_server,
             )
-        return await self._get_all_transactions(transactions_api, plan_id)
+        return await self._get(transactions_api, plan_id)
 
-    async def _get_all_transactions(
+    async def _get(
         self, transactions_api: TransactionsApi, plan_id: str
     ) -> TransactionsResponse:
         today = date.today()
         responses = await asyncio.gather(
             *(
-                self._get_transactions(
-                    transactions_api, plan_id, since_date, until_date
-                )
-                for since_date, until_date in _quarterly_chunks(self.first_month, today)
+                self._chunk(transactions_api, plan_id, since_date, until_date)
+                for since_date, until_date in _quarterly(self.first_month, today)
             )
         )
         transactions = [
@@ -739,7 +737,7 @@ class ChunkedTransactionsApi:
         )
 
     @retry(stop=stop_after_attempt(3))
-    async def _get_transactions(
+    async def _chunk(
         self,
         transactions_api: TransactionsApi,
         plan_id: str,
@@ -758,7 +756,7 @@ def _add_months(d: date, months: int) -> date:
     return date(d.year + month_index // 12, month_index % 12 + 1, 1)
 
 
-def _quarterly_chunks(first_month: date, today: date) -> Iterator[tuple[date, date]]:
+def _quarterly(first_month: date, today: date) -> Iterator[tuple[date, date]]:
     since_date = first_month
     while since_date <= today:
         until_date = min(_add_months(since_date, 3) - timedelta(days=1), today)

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -656,7 +656,11 @@ async def _get_plan_data(
         py.get(AccountsApi(context.api_client).get_accounts),
         py.get(CategoriesApi(context.api_client).get_categories),
         py.get(PayeesApi(context.api_client).get_payees),
-        py.get_transactions(TransactionsApi(context.api_client), plan.first_month),
+        py.get(
+            ChunkedTransactionsApi(
+                context.api_client, plan.first_month
+            ).get_transactions
+        ),
         py.get(ScheduledTransactionsApi(context.api_client).get_scheduled_transactions),
     )
     return (
@@ -689,28 +693,33 @@ class _ProgressYnab:
         finally:
             self.context.progress.update(self.task_id, advance=1)
 
+
+@dataclass(slots=True, frozen=True)
+class ChunkedTransactionsApi:
+    api_client: ApiClient
+    first_month: date
+
     async def get_transactions(
-        self, transactions_api: TransactionsApi, first_month: date
+        self, *, plan_id: str, last_knowledge_of_server: int | None
     ) -> TransactionsResponse:
-        last_knowledge_of_server = self.lkos.get(self.plan_id)
-        try:
-            if last_knowledge_of_server is not None:
-                return await transactions_api.get_transactions(
-                    plan_id=self.plan_id,
-                    last_knowledge_of_server=last_knowledge_of_server,
-                )
-            return await self._get_all_transactions(transactions_api, first_month)
-        finally:
-            self.context.progress.update(self.task_id, advance=1)
+        transactions_api = TransactionsApi(self.api_client)
+        if last_knowledge_of_server is not None:
+            return await transactions_api.get_transactions(
+                plan_id=plan_id,
+                last_knowledge_of_server=last_knowledge_of_server,
+            )
+        return await self._get_all_transactions(transactions_api, plan_id)
 
     async def _get_all_transactions(
-        self, transactions_api: TransactionsApi, first_month: date
+        self, transactions_api: TransactionsApi, plan_id: str
     ) -> TransactionsResponse:
         today = date.today()
         responses = await asyncio.gather(
             *(
-                self._get_transactions(transactions_api, since_date, until_date)
-                for since_date, until_date in _quarterly_chunks(first_month, today)
+                self._get_transactions(
+                    transactions_api, plan_id, since_date, until_date
+                )
+                for since_date, until_date in _quarterly_chunks(self.first_month, today)
             )
         )
         transactions = [
@@ -731,10 +740,14 @@ class _ProgressYnab:
 
     @retry(stop=stop_after_attempt(3))
     async def _get_transactions(
-        self, transactions_api: TransactionsApi, since_date: date, until_date: date
+        self,
+        transactions_api: TransactionsApi,
+        plan_id: str,
+        since_date: date,
+        until_date: date,
     ) -> TransactionsResponse:
         return await transactions_api.get_transactions(
-            plan_id=self.plan_id,
+            plan_id=plan_id,
             since_date=since_date,
             until_date=until_date,
         )

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from contextlib import contextmanager
 from dataclasses import dataclass
 from dataclasses import fields
+from datetime import date
 from importlib import resources
 from importlib.metadata import version
 from itertools import batched
@@ -35,6 +36,8 @@ from asyncio_for_ynab import ScheduledTransactionDetail
 from asyncio_for_ynab import ScheduledTransactionsApi
 from asyncio_for_ynab import TransactionDetail
 from asyncio_for_ynab import TransactionsApi
+from asyncio_for_ynab import TransactionsResponse
+from asyncio_for_ynab import TransactionsResponseData
 from rich.progress import BarColumn
 from rich.progress import Progress
 from rich.progress import TaskID
@@ -651,7 +654,7 @@ async def _get_plan_data(
         py.get(AccountsApi(context.api_client).get_accounts),
         py.get(CategoriesApi(context.api_client).get_categories),
         py.get(PayeesApi(context.api_client).get_payees),
-        py.get(TransactionsApi(context.api_client).get_transactions),
+        py.get_transactions(plan.first_month),
         py.get(ScheduledTransactionsApi(context.api_client).get_scheduled_transactions),
     )
     return (
@@ -683,6 +686,49 @@ class _ProgressYnab:
             )
         finally:
             self.context.progress.update(self.task_id, advance=1)
+
+    async def get_transactions(self, first_month: date | None) -> TransactionsResponse:
+        last_knowledge_of_server = self.lkos.get(self.plan_id)
+        try:
+            if last_knowledge_of_server is not None or first_month is None:
+                return await TransactionsApi(self.context.api_client).get_transactions(
+                    plan_id=self.plan_id,
+                    last_knowledge_of_server=last_knowledge_of_server,
+                )
+            return await self._get_transactions_by_year(first_month)
+        finally:
+            self.context.progress.update(self.task_id, advance=1)
+
+    async def _get_transactions_by_year(
+        self, first_month: date
+    ) -> TransactionsResponse:
+        responses = await asyncio.gather(
+            *(
+                self._get_transactions_for_year(year)
+                for year in range(first_month.year, date.today().year + 1)
+            )
+        )
+        transactions_by_id = {
+            transaction.id: transaction
+            for response in responses
+            for transaction in response.data.transactions
+        }
+        return TransactionsResponse(
+            data=TransactionsResponseData(
+                transactions=list(transactions_by_id.values()),
+                server_knowledge=max(
+                    response.data.server_knowledge for response in responses
+                ),
+            )
+        )
+
+    @retry(stop=stop_after_attempt(3))
+    async def _get_transactions_for_year(self, year: int) -> TransactionsResponse:
+        return await TransactionsApi(self.context.api_client).get_transactions(
+            plan_id=self.plan_id,
+            since_date=date(year, 1, 1),
+            until_date=date(year, 12, 31),
+        )
 
 
 def main(

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -721,7 +721,7 @@ class _ProgressYnab:
             for transaction in response.data.transactions
         ]
         ids = [transaction.id for transaction in transactions]
-        assert len(set(ids)) == len(ids)
+        assert len(set(ids)) == len(ids)  # paranoid check for no overlap across chunks
         return TransactionsResponse(
             data=TransactionsResponseData(
                 transactions=transactions,

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -735,13 +735,13 @@ class ChunkedTransactionsApi:
         self,
         transactions_api: TransactionsApi,
         plan_id: str,
-        sd: date,
-        ud: date,
+        since_date: date,
+        until_date: date,
     ) -> TransactionsResponse:
         return await transactions_api.get_transactions(
             plan_id=plan_id,
-            since_date=sd,
-            until_date=ud,
+            since_date=since_date,
+            until_date=until_date,
         )
 
 

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -649,6 +649,7 @@ async def _get_plan_data(
     context: _Context, plan: PlanSummary, lkos: dict[str, int], task_id: TaskID
 ) -> tuple[str, _YnabPlanData]:
     plan_id = str(plan.id)
+    assert plan.first_month is not None
     py = _ProgressYnab(context, plan_id, lkos, task_id)
     accounts, categories, payees, transactions, scheduled = await asyncio.gather(
         py.get(AccountsApi(context.api_client).get_accounts),
@@ -687,10 +688,10 @@ class _ProgressYnab:
         finally:
             self.context.progress.update(self.task_id, advance=1)
 
-    async def get_transactions(self, first_month: date | None) -> TransactionsResponse:
+    async def get_transactions(self, first_month: date) -> TransactionsResponse:
         last_knowledge_of_server = self.lkos.get(self.plan_id)
         try:
-            if last_knowledge_of_server is not None or first_month is None:
+            if last_knowledge_of_server is not None:
                 return await TransactionsApi(self.context.api_client).get_transactions(
                     plan_id=self.plan_id,
                     last_knowledge_of_server=last_knowledge_of_server,

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -6,6 +6,7 @@ import os
 from contextlib import asynccontextmanager
 from contextlib import contextmanager
 from dataclasses import dataclass
+from dataclasses import field
 from dataclasses import fields
 from datetime import date
 from importlib import resources
@@ -677,6 +678,10 @@ class _ProgressYnab:
     plan_id: str
     lkos: dict[str, int]
     task_id: TaskID
+    _transactions_api: TransactionsApi = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._transactions_api = TransactionsApi(self.context.api_client)
 
     @retry(stop=stop_after_attempt(3))
     async def get[T](self, endpoint: Callable[..., Awaitable[T]]) -> T:
@@ -692,7 +697,7 @@ class _ProgressYnab:
         last_knowledge_of_server = self.lkos.get(self.plan_id)
         try:
             if last_knowledge_of_server is not None:
-                return await TransactionsApi(self.context.api_client).get_transactions(
+                return await self._transactions_api.get_transactions(
                     plan_id=self.plan_id,
                     last_knowledge_of_server=last_knowledge_of_server,
                 )
@@ -725,7 +730,7 @@ class _ProgressYnab:
 
     @retry(stop=stop_after_attempt(3))
     async def _get_transactions_for_year(self, year: int) -> TransactionsResponse:
-        return await TransactionsApi(self.context.api_client).get_transactions(
+        return await self._transactions_api.get_transactions(
             plan_id=self.plan_id,
             since_date=date(year, 1, 1),
             until_date=date(year, 12, 31),

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import fields
 from datetime import date
+from datetime import timedelta
 from importlib import resources
 from importlib.metadata import version
 from itertools import batched
@@ -701,17 +702,18 @@ class _ProgressYnab:
                     plan_id=self.plan_id,
                     last_knowledge_of_server=last_knowledge_of_server,
                 )
-            return await self._get_transactions_by_year(first_month)
+            return await self._get_transactions_in_chunks(first_month)
         finally:
             self.context.progress.update(self.task_id, advance=1)
 
-    async def _get_transactions_by_year(
+    async def _get_transactions_in_chunks(
         self, first_month: date
     ) -> TransactionsResponse:
+        today = date.today()
         responses = await asyncio.gather(
             *(
-                self._get_transactions_for_year(year)
-                for year in range(first_month.year, date.today().year + 1)
+                self._get_transactions_for_chunk(since_date, until_date)
+                for since_date, until_date in _quarterly_chunks(first_month, today)
             )
         )
         transactions_by_id = {
@@ -729,12 +731,27 @@ class _ProgressYnab:
         )
 
     @retry(stop=stop_after_attempt(3))
-    async def _get_transactions_for_year(self, year: int) -> TransactionsResponse:
+    async def _get_transactions_for_chunk(
+        self, since_date: date, until_date: date
+    ) -> TransactionsResponse:
         return await self._transactions_api.get_transactions(
             plan_id=self.plan_id,
-            since_date=date(year, 1, 1),
-            until_date=date(year, 12, 31),
+            since_date=since_date,
+            until_date=until_date,
         )
+
+
+def _add_months(d: date, months: int) -> date:
+    month_index = d.month - 1 + months
+    return date(d.year + month_index // 12, month_index % 12 + 1, 1)
+
+
+def _quarterly_chunks(first_month: date, today: date) -> Iterator[tuple[date, date]]:
+    since_date = first_month
+    while since_date <= today:
+        until_date = min(_add_months(since_date, 3) - timedelta(days=1), today)
+        yield since_date, until_date
+        since_date = until_date + timedelta(days=1)
 
 
 def main(

--- a/sqlite_export_for_ynab/_main.py
+++ b/sqlite_export_for_ynab/_main.py
@@ -699,19 +699,17 @@ class _ProgressYnab:
                     plan_id=self.plan_id,
                     last_knowledge_of_server=last_knowledge_of_server,
                 )
-            return await self._get_transactions_in_chunks(transactions_api, first_month)
+            return await self._get_all_transactions(transactions_api, first_month)
         finally:
             self.context.progress.update(self.task_id, advance=1)
 
-    async def _get_transactions_in_chunks(
+    async def _get_all_transactions(
         self, transactions_api: TransactionsApi, first_month: date
     ) -> TransactionsResponse:
         today = date.today()
         responses = await asyncio.gather(
             *(
-                self._get_transactions_for_chunk(
-                    transactions_api, since_date, until_date
-                )
+                self._get_transactions(transactions_api, since_date, until_date)
                 for since_date, until_date in _quarterly_chunks(first_month, today)
             )
         )
@@ -732,7 +730,7 @@ class _ProgressYnab:
         )
 
     @retry(stop=stop_after_attempt(3))
-    async def _get_transactions_for_chunk(
+    async def _get_transactions(
         self, transactions_api: TransactionsApi, since_date: date, until_date: date
     ) -> TransactionsResponse:
         return await transactions_api.get_transactions(

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -69,6 +69,11 @@ PLANS: list[PlanSummary] = [
 SERVER_KNOWLEDGE_1 = 107667
 SERVER_KNOWLEDGE_2 = 107668
 
+TRANSACTION_CHUNKS = [
+    (date(2021, 1, 1), date(2021, 3, 31)),
+    (date(2021, 4, 1), date(2021, 6, 30)),
+]
+
 LKOS = {
     PLAN_ID_1: SERVER_KNOWLEDGE_1,
     PLAN_ID_2: SERVER_KNOWLEDGE_2,

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -37,6 +37,7 @@ PLANS: list[PlanSummary] = [
     PlanSummary(
         id=UUID(PLAN_ID_1),
         name="Plan 1",
+        first_month=date.fromisoformat("2024-01-01"),
         currency_format=CurrencyFormat(
             currency_symbol="$",
             decimal_digits=2,
@@ -51,6 +52,7 @@ PLANS: list[PlanSummary] = [
     PlanSummary(
         id=UUID(PLAN_ID_2),
         name="Plan 2",
+        first_month=date.fromisoformat("2024-01-01"),
         currency_format=CurrencyFormat(
             currency_symbol="$",
             decimal_digits=2,

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -22,6 +22,7 @@ from sqlite_export_for_ynab._main import _get_plan_summaries
 from sqlite_export_for_ynab._main import _PACKAGE
 from sqlite_export_for_ynab._main import _PROGRESS_COLUMNS
 from sqlite_export_for_ynab._main import _ProgressYnab
+from sqlite_export_for_ynab._main import _quarterly_chunks
 from sqlite_export_for_ynab._main import async_main
 from sqlite_export_for_ynab._main import asyncio_for_ynab
 from sqlite_export_for_ynab._main import contents
@@ -130,19 +131,54 @@ async def test_progress_ynab_get_transactions_uses_last_knowledge_of_server_when
     assert response.data.transactions == TRANSACTIONS
 
 
+@pytest.mark.parametrize(
+    ("first_month", "today", "expected_chunks"),
+    (
+        pytest.param(
+            date(2021, 4, 1),
+            date(2022, 1, 15),
+            [
+                (date(2021, 4, 1), date(2021, 6, 30)),
+                (date(2021, 7, 1), date(2021, 9, 30)),
+                (date(2021, 10, 1), date(2021, 12, 31)),
+                (date(2022, 1, 1), date(2022, 1, 15)),
+            ],
+            id="spans-multiple-quarters-with-partial-last-chunk",
+        ),
+        pytest.param(
+            date(2024, 1, 1),
+            date(2024, 1, 1),
+            [(date(2024, 1, 1), date(2024, 1, 1))],
+            id="single-day-range",
+        ),
+    ),
+)
+def test_quarterly_chunks(first_month, today, expected_chunks):
+    assert list(_quarterly_chunks(first_month, today)) == expected_chunks
+
+
 @pytest.mark.asyncio
-async def test_progress_ynab_get_transactions_chunks_by_year_when_full_refresh(context):
+async def test_progress_ynab_get_transactions_merges_chunk_responses(
+    context, monkeypatch
+):
     task_id = context.progress.add_task("Plan Data", total=1)
     py = _ProgressYnab(context, PLAN_ID_1, {}, task_id)
 
-    current_year = date.today().year
+    chunks = [
+        (date(2021, 1, 1), date(2021, 3, 31)),
+        (date(2021, 4, 1), date(2021, 6, 30)),
+    ]
+    monkeypatch.setattr(
+        "sqlite_export_for_ynab._main._quarterly_chunks",
+        lambda first_month, today: iter(chunks),
+    )
+
     old_transaction, new_transaction, _ = TRANSACTIONS
 
     def side_effect(*, plan_id, since_date, until_date):
         assert plan_id == PLAN_ID_1
-        assert since_date == date(since_date.year, 1, 1)
-        assert until_date == date(since_date.year, 12, 31)
-        if since_date.year == current_year - 1:
+        assert (since_date, until_date) in chunks
+        if since_date == chunks[0][0]:
             return transactions_response([old_transaction], SERVER_KNOWLEDGE_1)
         return transactions_response([new_transaction], SERVER_KNOWLEDGE_2)
 
@@ -150,7 +186,7 @@ async def test_progress_ynab_get_transactions_chunks_by_year_when_full_refresh(c
         "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
         new=AsyncMock(side_effect=side_effect),
     ):
-        response = await py.get_transactions(date(current_year - 1, 6, 1))
+        response = await py.get_transactions(date(2021, 1, 1))
 
     assert {t.id for t in response.data.transactions} == {
         old_transaction.id,

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -110,6 +110,15 @@ async def context(tmp_path):
             yield _Context(progress, con, lock, Mock(spec=asyncio_for_ynab.ApiClient))
 
 
+_LKO_TRANSACTIONS_MOCK = AsyncMock(
+    return_value=transactions_response(TRANSACTIONS, SERVER_KNOWLEDGE_1)
+)
+
+
+@patch(
+    "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
+    new=_LKO_TRANSACTIONS_MOCK,
+)
 @pytest.mark.asyncio
 async def test_progress_ynab_get_transactions_uses_last_knowledge_of_server_when_present(
     context,
@@ -117,15 +126,9 @@ async def test_progress_ynab_get_transactions_uses_last_knowledge_of_server_when
     task_id = context.progress.add_task("Plan Data", total=1)
     py = _ProgressYnab(context, PLAN_ID_1, LKOS, task_id)
 
-    with patch(
-        "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
-        new=AsyncMock(
-            return_value=transactions_response(TRANSACTIONS, SERVER_KNOWLEDGE_1)
-        ),
-    ) as get_transactions:
-        response = await py.get_transactions(date(2020, 1, 1))
+    response = await py.get_transactions(date(2020, 1, 1))
 
-    get_transactions.assert_awaited_once_with(
+    _LKO_TRANSACTIONS_MOCK.assert_awaited_once_with(
         plan_id=PLAN_ID_1, last_knowledge_of_server=LKOS[PLAN_ID_1]
     )
     assert response.data.transactions == TRANSACTIONS
@@ -157,37 +160,37 @@ def test_quarterly_chunks(first_month, today, expected_chunks):
     assert list(_quarterly_chunks(first_month, today)) == expected_chunks
 
 
+_CHUNK_MERGE_TEST_CHUNKS = [
+    (date(2021, 1, 1), date(2021, 3, 31)),
+    (date(2021, 4, 1), date(2021, 6, 30)),
+]
+
+
+def _chunk_merge_test_side_effect(*, plan_id, since_date, until_date):
+    assert plan_id == PLAN_ID_1
+    assert (since_date, until_date) in _CHUNK_MERGE_TEST_CHUNKS
+    old_transaction, new_transaction, _ = TRANSACTIONS
+    if since_date == _CHUNK_MERGE_TEST_CHUNKS[0][0]:
+        return transactions_response([old_transaction], SERVER_KNOWLEDGE_1)
+    return transactions_response([new_transaction], SERVER_KNOWLEDGE_2)
+
+
+@patch(
+    "sqlite_export_for_ynab._main._quarterly_chunks",
+    new=Mock(return_value=iter(_CHUNK_MERGE_TEST_CHUNKS)),
+)
+@patch(
+    "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
+    new=AsyncMock(side_effect=_chunk_merge_test_side_effect),
+)
 @pytest.mark.asyncio
 async def test_progress_ynab_get_transactions_merges_chunk_responses(context):
     task_id = context.progress.add_task("Plan Data", total=1)
     py = _ProgressYnab(context, PLAN_ID_1, {}, task_id)
 
-    chunks = [
-        (date(2021, 1, 1), date(2021, 3, 31)),
-        (date(2021, 4, 1), date(2021, 6, 30)),
-    ]
+    response = await py.get_transactions(date(2021, 1, 1))
 
     old_transaction, new_transaction, _ = TRANSACTIONS
-
-    def side_effect(*, plan_id, since_date, until_date):
-        assert plan_id == PLAN_ID_1
-        assert (since_date, until_date) in chunks
-        if since_date == chunks[0][0]:
-            return transactions_response([old_transaction], SERVER_KNOWLEDGE_1)
-        return transactions_response([new_transaction], SERVER_KNOWLEDGE_2)
-
-    with (
-        patch(
-            "sqlite_export_for_ynab._main._quarterly_chunks",
-            return_value=iter(chunks),
-        ),
-        patch(
-            "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
-            new=AsyncMock(side_effect=side_effect),
-        ),
-    ):
-        response = await py.get_transactions(date(2021, 1, 1))
-
     assert {t.id for t in response.data.transactions} == {
         old_transaction.id,
         new_transaction.id,

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import tomllib
+from datetime import date
 from pathlib import Path
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
@@ -20,6 +21,7 @@ from sqlite_export_for_ynab._main import _ENV_TOKEN
 from sqlite_export_for_ynab._main import _get_plan_summaries
 from sqlite_export_for_ynab._main import _PACKAGE
 from sqlite_export_for_ynab._main import _PROGRESS_COLUMNS
+from sqlite_export_for_ynab._main import _ProgressYnab
 from sqlite_export_for_ynab._main import async_main
 from sqlite_export_for_ynab._main import asyncio_for_ynab
 from sqlite_export_for_ynab._main import contents
@@ -71,6 +73,7 @@ from testing.fixtures import SCHEDULED_TRANSACTION_ID_3
 from testing.fixtures import SCHEDULED_TRANSACTIONS
 from testing.fixtures import scheduled_transactions_response
 from testing.fixtures import SERVER_KNOWLEDGE_1
+from testing.fixtures import SERVER_KNOWLEDGE_2
 from testing.fixtures import SUBTRANSACTION_ID_1
 from testing.fixtures import SUBTRANSACTION_ID_2
 from testing.fixtures import TOKEN
@@ -104,6 +107,77 @@ async def context(tmp_path):
                 tmp_path / "sqlite-export-for-ynab-test.lock"
             )
             yield _Context(progress, con, lock, Mock(spec=asyncio_for_ynab.ApiClient))
+
+
+@pytest.mark.asyncio
+async def test_progress_ynab_get_transactions_uses_last_knowledge_of_server_when_present(
+    context,
+):
+    task_id = context.progress.add_task("Plan Data", total=1)
+    py = _ProgressYnab(context, PLAN_ID_1, LKOS, task_id)
+
+    with patch(
+        "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
+        new=AsyncMock(
+            return_value=transactions_response(TRANSACTIONS, SERVER_KNOWLEDGE_1)
+        ),
+    ) as get_transactions:
+        response = await py.get_transactions(date(2020, 1, 1))
+
+    get_transactions.assert_awaited_once_with(
+        plan_id=PLAN_ID_1, last_knowledge_of_server=LKOS[PLAN_ID_1]
+    )
+    assert response.data.transactions == TRANSACTIONS
+
+
+@pytest.mark.asyncio
+async def test_progress_ynab_get_transactions_uses_single_call_when_no_first_month(
+    context,
+):
+    task_id = context.progress.add_task("Plan Data", total=1)
+    py = _ProgressYnab(context, PLAN_ID_1, {}, task_id)
+
+    with patch(
+        "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
+        new=AsyncMock(
+            return_value=transactions_response(TRANSACTIONS, SERVER_KNOWLEDGE_1)
+        ),
+    ) as get_transactions:
+        response = await py.get_transactions(None)
+
+    get_transactions.assert_awaited_once_with(
+        plan_id=PLAN_ID_1, last_knowledge_of_server=None
+    )
+    assert response.data.transactions == TRANSACTIONS
+
+
+@pytest.mark.asyncio
+async def test_progress_ynab_get_transactions_chunks_by_year_when_full_refresh(context):
+    task_id = context.progress.add_task("Plan Data", total=1)
+    py = _ProgressYnab(context, PLAN_ID_1, {}, task_id)
+
+    current_year = date.today().year
+    old_transaction, new_transaction, _ = TRANSACTIONS
+
+    def side_effect(*, plan_id, since_date, until_date):
+        assert plan_id == PLAN_ID_1
+        assert since_date == date(since_date.year, 1, 1)
+        assert until_date == date(since_date.year, 12, 31)
+        if since_date.year == current_year - 1:
+            return transactions_response([old_transaction], SERVER_KNOWLEDGE_1)
+        return transactions_response([new_transaction], SERVER_KNOWLEDGE_2)
+
+    with patch(
+        "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
+        new=AsyncMock(side_effect=side_effect),
+    ):
+        response = await py.get_transactions(date(current_year - 1, 6, 1))
+
+    assert {t.id for t in response.data.transactions} == {
+        old_transaction.id,
+        new_transaction.id,
+    }
+    assert response.data.server_knowledge == SERVER_KNOWLEDGE_2
 
 
 @pytest.mark.parametrize(

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -78,6 +78,7 @@ from testing.fixtures import SERVER_KNOWLEDGE_2
 from testing.fixtures import SUBTRANSACTION_ID_1
 from testing.fixtures import SUBTRANSACTION_ID_2
 from testing.fixtures import TOKEN
+from testing.fixtures import TRANSACTION_CHUNKS
 from testing.fixtures import TRANSACTION_ID_1
 from testing.fixtures import TRANSACTION_ID_2
 from testing.fixtures import TRANSACTION_ID_3
@@ -110,26 +111,21 @@ async def context(tmp_path):
             yield _Context(progress, con, lock, Mock(spec=asyncio_for_ynab.ApiClient))
 
 
-_LKO_TRANSACTIONS_MOCK = AsyncMock(
-    return_value=transactions_response(TRANSACTIONS, SERVER_KNOWLEDGE_1)
-)
-
-
-@patch(
-    "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
-    new=_LKO_TRANSACTIONS_MOCK,
-)
+@patch("sqlite_export_for_ynab._main.TransactionsApi.get_transactions")
 @pytest.mark.asyncio
 async def test_progress_ynab_get_transactions_uses_last_knowledge_of_server_when_present(
-    context,
+    get_transactions, context
 ):
+    get_transactions.return_value = transactions_response(
+        TRANSACTIONS, SERVER_KNOWLEDGE_1
+    )
     task_id = context.progress.add_task("Plan Data", total=1)
     py = _ProgressYnab(context, PLAN_ID_1, LKOS, task_id)
     transactions_api = asyncio_for_ynab.TransactionsApi(context.api_client)
 
     response = await py.get_transactions(transactions_api, date(2020, 1, 1))
 
-    _LKO_TRANSACTIONS_MOCK.assert_awaited_once_with(
+    get_transactions.assert_awaited_once_with(
         plan_id=PLAN_ID_1, last_knowledge_of_server=LKOS[PLAN_ID_1]
     )
     assert response.data.transactions == TRANSACTIONS
@@ -161,31 +157,23 @@ def test_quarterly_chunks(first_month, today, expected_chunks):
     assert list(_quarterly_chunks(first_month, today)) == expected_chunks
 
 
-_CHUNK_MERGE_TEST_CHUNKS = [
-    (date(2021, 1, 1), date(2021, 3, 31)),
-    (date(2021, 4, 1), date(2021, 6, 30)),
-]
-
-
 def _chunk_merge_test_side_effect(*, plan_id, since_date, until_date):
     assert plan_id == PLAN_ID_1
-    assert (since_date, until_date) in _CHUNK_MERGE_TEST_CHUNKS
+    assert (since_date, until_date) in TRANSACTION_CHUNKS
     old_transaction, new_transaction, _ = TRANSACTIONS
-    if since_date == _CHUNK_MERGE_TEST_CHUNKS[0][0]:
+    if since_date == TRANSACTION_CHUNKS[0][0]:
         return transactions_response([old_transaction], SERVER_KNOWLEDGE_1)
     return transactions_response([new_transaction], SERVER_KNOWLEDGE_2)
 
 
-@patch(
-    "sqlite_export_for_ynab._main._quarterly_chunks",
-    new=Mock(return_value=iter(_CHUNK_MERGE_TEST_CHUNKS)),
-)
-@patch(
-    "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
-    new=AsyncMock(side_effect=_chunk_merge_test_side_effect),
-)
+@patch("sqlite_export_for_ynab._main._quarterly_chunks")
+@patch("sqlite_export_for_ynab._main.TransactionsApi.get_transactions")
 @pytest.mark.asyncio
-async def test_progress_ynab_get_transactions_merges_chunk_responses(context):
+async def test_progress_ynab_get_transactions_merges_chunk_responses(
+    get_transactions, quarterly_chunks, context
+):
+    get_transactions.side_effect = _chunk_merge_test_side_effect
+    quarterly_chunks.return_value = iter(TRANSACTION_CHUNKS)
     task_id = context.progress.add_task("Plan Data", total=1)
     py = _ProgressYnab(context, PLAN_ID_1, {}, task_id)
     transactions_api = asyncio_for_ynab.TransactionsApi(context.api_client)

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -125,8 +125,9 @@ async def test_progress_ynab_get_transactions_uses_last_knowledge_of_server_when
 ):
     task_id = context.progress.add_task("Plan Data", total=1)
     py = _ProgressYnab(context, PLAN_ID_1, LKOS, task_id)
+    transactions_api = asyncio_for_ynab.TransactionsApi(context.api_client)
 
-    response = await py.get_transactions(date(2020, 1, 1))
+    response = await py.get_transactions(transactions_api, date(2020, 1, 1))
 
     _LKO_TRANSACTIONS_MOCK.assert_awaited_once_with(
         plan_id=PLAN_ID_1, last_knowledge_of_server=LKOS[PLAN_ID_1]
@@ -187,8 +188,9 @@ def _chunk_merge_test_side_effect(*, plan_id, since_date, until_date):
 async def test_progress_ynab_get_transactions_merges_chunk_responses(context):
     task_id = context.progress.add_task("Plan Data", total=1)
     py = _ProgressYnab(context, PLAN_ID_1, {}, task_id)
+    transactions_api = asyncio_for_ynab.TransactionsApi(context.api_client)
 
-    response = await py.get_transactions(date(2021, 1, 1))
+    response = await py.get_transactions(transactions_api, date(2021, 1, 1))
 
     old_transaction, new_transaction, _ = TRANSACTIONS
     assert {t.id for t in response.data.transactions} == {
@@ -196,6 +198,11 @@ async def test_progress_ynab_get_transactions_merges_chunk_responses(context):
         new_transaction.id,
     }
     assert response.data.server_knowledge == SERVER_KNOWLEDGE_2
+
+
+def _transactions_in_range_side_effect(*, plan_id, since_date, until_date):
+    matching = [t for t in TRANSACTIONS if since_date <= t.var_date <= until_date]
+    return transactions_response(matching, SERVER_KNOWLEDGE_1)
 
 
 @pytest.mark.parametrize(
@@ -1201,7 +1208,7 @@ async def test_sync_no_data_quiet(tmp_path, capsys):
 )
 @patch(
     "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
-    new=AsyncMock(return_value=transactions_response(TRANSACTIONS, SERVER_KNOWLEDGE_1)),
+    new=AsyncMock(side_effect=_transactions_in_range_side_effect),
 )
 @patch(
     "sqlite_export_for_ynab._main.ScheduledTransactionsApi.get_scheduled_transactions",

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -21,10 +21,10 @@ from sqlite_export_for_ynab._main import _ENV_TOKEN
 from sqlite_export_for_ynab._main import _get_plan_summaries
 from sqlite_export_for_ynab._main import _PACKAGE
 from sqlite_export_for_ynab._main import _PROGRESS_COLUMNS
-from sqlite_export_for_ynab._main import _ProgressYnab
 from sqlite_export_for_ynab._main import _quarterly_chunks
 from sqlite_export_for_ynab._main import async_main
 from sqlite_export_for_ynab._main import asyncio_for_ynab
+from sqlite_export_for_ynab._main import ChunkedTransactionsApi
 from sqlite_export_for_ynab._main import contents
 from sqlite_export_for_ynab._main import get_last_knowledge_of_server
 from sqlite_export_for_ynab._main import get_relations
@@ -113,17 +113,19 @@ async def context(tmp_path):
 
 @patch("sqlite_export_for_ynab._main.TransactionsApi.get_transactions")
 @pytest.mark.asyncio
-async def test_progress_ynab_get_transactions_uses_last_knowledge_of_server_when_present(
+async def test_chunked_transactions_api_uses_last_knowledge_of_server_when_present(
     get_transactions, context
 ):
     get_transactions.return_value = transactions_response(
         TRANSACTIONS, SERVER_KNOWLEDGE_1
     )
-    task_id = context.progress.add_task("Plan Data", total=1)
-    py = _ProgressYnab(context, PLAN_ID_1, LKOS, task_id)
-    transactions_api = asyncio_for_ynab.TransactionsApi(context.api_client)
+    chunked_transactions_api = ChunkedTransactionsApi(
+        context.api_client, date(2020, 1, 1)
+    )
 
-    response = await py.get_transactions(transactions_api, date(2020, 1, 1))
+    response = await chunked_transactions_api.get_transactions(
+        plan_id=PLAN_ID_1, last_knowledge_of_server=LKOS[PLAN_ID_1]
+    )
 
     get_transactions.assert_awaited_once_with(
         plan_id=PLAN_ID_1, last_knowledge_of_server=LKOS[PLAN_ID_1]
@@ -169,16 +171,18 @@ def _chunk_merge_test_side_effect(*, plan_id, since_date, until_date):
 @patch("sqlite_export_for_ynab._main._quarterly_chunks")
 @patch("sqlite_export_for_ynab._main.TransactionsApi.get_transactions")
 @pytest.mark.asyncio
-async def test_progress_ynab_get_transactions_merges_chunk_responses(
+async def test_chunked_transactions_api_merges_chunk_responses(
     get_transactions, quarterly_chunks, context
 ):
     get_transactions.side_effect = _chunk_merge_test_side_effect
     quarterly_chunks.return_value = iter(TRANSACTION_CHUNKS)
-    task_id = context.progress.add_task("Plan Data", total=1)
-    py = _ProgressYnab(context, PLAN_ID_1, {}, task_id)
-    transactions_api = asyncio_for_ynab.TransactionsApi(context.api_client)
+    chunked_transactions_api = ChunkedTransactionsApi(
+        context.api_client, date(2021, 1, 1)
+    )
 
-    response = await py.get_transactions(transactions_api, date(2021, 1, 1))
+    response = await chunked_transactions_api.get_transactions(
+        plan_id=PLAN_ID_1, last_knowledge_of_server=None
+    )
 
     old_transaction, new_transaction, _ = TRANSACTIONS
     assert {t.id for t in response.data.transactions} == {

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -158,9 +158,7 @@ def test_quarterly_chunks(first_month, today, expected_chunks):
 
 
 @pytest.mark.asyncio
-async def test_progress_ynab_get_transactions_merges_chunk_responses(
-    context, monkeypatch
-):
+async def test_progress_ynab_get_transactions_merges_chunk_responses(context):
     task_id = context.progress.add_task("Plan Data", total=1)
     py = _ProgressYnab(context, PLAN_ID_1, {}, task_id)
 
@@ -168,10 +166,6 @@ async def test_progress_ynab_get_transactions_merges_chunk_responses(
         (date(2021, 1, 1), date(2021, 3, 31)),
         (date(2021, 4, 1), date(2021, 6, 30)),
     ]
-    monkeypatch.setattr(
-        "sqlite_export_for_ynab._main._quarterly_chunks",
-        lambda first_month, today: iter(chunks),
-    )
 
     old_transaction, new_transaction, _ = TRANSACTIONS
 
@@ -182,9 +176,15 @@ async def test_progress_ynab_get_transactions_merges_chunk_responses(
             return transactions_response([old_transaction], SERVER_KNOWLEDGE_1)
         return transactions_response([new_transaction], SERVER_KNOWLEDGE_2)
 
-    with patch(
-        "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
-        new=AsyncMock(side_effect=side_effect),
+    with (
+        patch(
+            "sqlite_export_for_ynab._main._quarterly_chunks",
+            return_value=iter(chunks),
+        ),
+        patch(
+            "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
+            new=AsyncMock(side_effect=side_effect),
+        ),
     ):
         response = await py.get_transactions(date(2021, 1, 1))
 

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -188,11 +188,6 @@ async def test_progress_ynab_get_transactions_merges_chunk_responses(
     assert response.data.server_knowledge == SERVER_KNOWLEDGE_2
 
 
-def _transactions_in_range_side_effect(*, plan_id, since_date, until_date):
-    matching = [t for t in TRANSACTIONS if since_date <= t.var_date <= until_date]
-    return transactions_response(matching, SERVER_KNOWLEDGE_1)
-
-
 @pytest.mark.parametrize(
     ("xdg_data_home", "expected_prefix"),
     (
@@ -1196,7 +1191,12 @@ async def test_sync_no_data_quiet(tmp_path, capsys):
 )
 @patch(
     "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
-    new=AsyncMock(side_effect=_transactions_in_range_side_effect),
+    new=AsyncMock(
+        side_effect=lambda *, plan_id, since_date, until_date: transactions_response(
+            [t for t in TRANSACTIONS if since_date <= t.var_date <= until_date],
+            SERVER_KNOWLEDGE_1,
+        )
+    ),
 )
 @patch(
     "sqlite_export_for_ynab._main.ScheduledTransactionsApi.get_scheduled_transactions",

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -131,27 +131,6 @@ async def test_progress_ynab_get_transactions_uses_last_knowledge_of_server_when
 
 
 @pytest.mark.asyncio
-async def test_progress_ynab_get_transactions_uses_single_call_when_no_first_month(
-    context,
-):
-    task_id = context.progress.add_task("Plan Data", total=1)
-    py = _ProgressYnab(context, PLAN_ID_1, {}, task_id)
-
-    with patch(
-        "sqlite_export_for_ynab._main.TransactionsApi.get_transactions",
-        new=AsyncMock(
-            return_value=transactions_response(TRANSACTIONS, SERVER_KNOWLEDGE_1)
-        ),
-    ) as get_transactions:
-        response = await py.get_transactions(None)
-
-    get_transactions.assert_awaited_once_with(
-        plan_id=PLAN_ID_1, last_knowledge_of_server=None
-    )
-    assert response.data.transactions == TRANSACTIONS
-
-
-@pytest.mark.asyncio
 async def test_progress_ynab_get_transactions_chunks_by_year_when_full_refresh(context):
     task_id = context.progress.add_task("Plan Data", total=1)
     py = _ProgressYnab(context, PLAN_ID_1, {}, task_id)

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -21,7 +21,7 @@ from sqlite_export_for_ynab._main import _ENV_TOKEN
 from sqlite_export_for_ynab._main import _get_plan_summaries
 from sqlite_export_for_ynab._main import _PACKAGE
 from sqlite_export_for_ynab._main import _PROGRESS_COLUMNS
-from sqlite_export_for_ynab._main import _quarterly_chunks
+from sqlite_export_for_ynab._main import _quarterly
 from sqlite_export_for_ynab._main import async_main
 from sqlite_export_for_ynab._main import asyncio_for_ynab
 from sqlite_export_for_ynab._main import ChunkedTransactionsApi
@@ -155,8 +155,8 @@ async def test_chunked_transactions_api_uses_last_knowledge_of_server_when_prese
         ),
     ),
 )
-def test_quarterly_chunks(first_month, today, expected_chunks):
-    assert list(_quarterly_chunks(first_month, today)) == expected_chunks
+def test_quarterly(first_month, today, expected_chunks):
+    assert list(_quarterly(first_month, today)) == expected_chunks
 
 
 def _chunk_merge_test_side_effect(*, plan_id, since_date, until_date):
@@ -168,7 +168,7 @@ def _chunk_merge_test_side_effect(*, plan_id, since_date, until_date):
     return transactions_response([new_transaction], SERVER_KNOWLEDGE_2)
 
 
-@patch("sqlite_export_for_ynab._main._quarterly_chunks")
+@patch("sqlite_export_for_ynab._main._quarterly")
 @patch("sqlite_export_for_ynab._main.TransactionsApi.get_transactions")
 @pytest.mark.asyncio
 async def test_chunked_transactions_api_merges_chunk_responses(


### PR DESCRIPTION
#### Problem
YNAB's `get_transactions` defaults `since_date` to one year ago, so `--full-refresh` silently only pulled the last year of transactions even for older budgets.

#### Solution
On full refresh (no last known server knowledge for a plan), fetch transactions in parallel quarterly chunks using `since_date`/`until_date` (added in asyncio-for-ynab 1.85.0), merging results and taking the max server knowledge. Incremental syncs are unaffected.