### PR TITLE
Change dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ version: 2
 multi-ecosystem-groups:
   default:
     schedule:
-      interval: cron
-      cronjob: every day at 7am
+      interval: weekly
 
 updates:
 - package-ecosystem: github-actions


### PR DESCRIPTION
#### Problem
Dependabot ran on a daily cron schedule.

#### Solution
Set schedule interval to weekly.