### PR TITLE
Add actionlint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,3 +78,9 @@ repos:
   hooks:
   - id: zizmor
     args: [--no-progress, --fix]
+- repo: https://github.com/rhysd/actionlint
+  rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # frozen: v1.7.12
+  hooks:
+  - id: actionlint
+    additional_dependencies:
+    - github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest


### PR DESCRIPTION
#### Problem
Shell embedded in GitHub Actions `run:` steps isn't linted by anything in this repo.

#### Solution
Add the `actionlint` pre-commit hook, with a go-installable shellcheck as an additional dependency so shellcheck integration works without a system install (needed for pre-commit.ci).