### PR TITLE
Add py315 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     if: needs.changes.outputs.project_files == 'true'
     uses: asottile/workflows/.github/workflows/tox.yml@75fa946a6d3d763b75b3a6669c18dc4d1822e939 # v1.11.1
     with:
-      env: '["py312", "py313", "py314", "pypy7.3.20"]' # https://github.com/actions/runner-images/blob/4847d9e554d1ad62acec5c5bddfc6175fe1bef4e/images/ubuntu/Ubuntu2204-Readme.md#pypy
+      env: '["py312", "py313", "py314", "py315", "pypy7.3.20"]' # https://github.com/actions/runner-images/blob/4847d9e554d1ad62acec5c5bddfc6175fe1bef4e/images/ubuntu/Ubuntu2204-Readme.md#pypy
   main:
     needs: [changes, main-real]
     if: always()


### PR DESCRIPTION
#### Problem
Test matrix does not cover Python 3.15.

#### Solution
Add py315 to the tox environments run in CI.